### PR TITLE
feat: registration with authorized ab domains only

### DIFF
--- a/lib/pages/app_layout.dart
+++ b/lib/pages/app_layout.dart
@@ -38,6 +38,9 @@ class AppLayoutState extends ResponsiveState<AppLayout> {
       prefs: prefs!,
     );
 
+    context.read<AuthBloc>().add(const LoadConfig());
+
+
     if (context.read<AuthBloc>().state.user != null) {
       WidgetsBinding.instance.addPostFrameCallback((_) async {
         if (context.read<AuthBloc>().state.user?.devices == null) {

--- a/lib/pages/mails/views/drafts.dart
+++ b/lib/pages/mails/views/drafts.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mail/blocs/mail/mail_bloc.dart';
 import 'package:mail/pages/mails/filtered_mail.dart';
+import 'package:mail/services/sync.service.dart';
 
 class DraftScreen extends StatefulWidget {
   const DraftScreen({super.key});
@@ -13,9 +14,10 @@ class DraftScreen extends StatefulWidget {
 class _DraftScreenState extends State<DraftScreen> {
   @override
   void initState() {
-    context.read<MailBloc>().add(const LoadMails());
+    SyncService.sync(context);
     super.initState();
   }
+
   @override
   Widget build(BuildContext context) {
     return FilteredMailScreen(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,7 +40,7 @@ dependencies:
   ab_shared:
     git:
       url: https://github.com/atomic-blend/app-shared.git
-      ref: v0.4.0
+      ref: v0.5.0
     # path: ../ab_shared
 
     # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
Linked to : https://github.com/atomic-blend/app-shared/pull/5

Simply load the config from the backend with auth bloc at startup